### PR TITLE
fix: Override Git config core.abbrev when reading version from SCM

### DIFF
--- a/src/pdm/backend/hooks/version/scm.py
+++ b/src/pdm/backend/hooks/version/scm.py
@@ -193,6 +193,8 @@ def git_parse_version(root: StrPath, config: Config) -> SCMVersion | None:
         warnings.warn(f"{repo!r} is shallow and may cause errors")
     describe_cmd = [
         git,
+        "-c",
+        "core.abbrev=auto",
         "describe",
         "--dirty",
         "--tags",

--- a/tests/pdm/backend/hooks/version/test_scm.py
+++ b/tests/pdm/backend/hooks/version/test_scm.py
@@ -139,7 +139,8 @@ class GitScm(Scm):
 
     @property
     def current_hash(self) -> str:
-        return "g" + self.run("rev-parse", "--short", "HEAD").strip()
+        return "g" + self.run("-c", "core.abbrev=auto",
+                              "rev-parse", "--short", "HEAD").strip()
 
 
 class HgScm(Scm):


### PR DESCRIPTION
The configuration represents the length commit hashes are abbreviated to. As pdm-backend parses output of git describe to obtain the package version, this configuration affects format of package versions that must be represented with a commit hash part, which is quite surprising and may introduce reproducible issues.

Let's override the core.abbrev with auto and let git decide how long the hash, keeping the format of generated version consistent regardless of value of core.abbrev and fixing failures of
test__get_version_from_scm__returns_default_if_tag_cannot_be_parsed[git] with the git configuration set globally.